### PR TITLE
Adicionada a versão 1.0 da API Package_Handler_Transmitter

### DIFF
--- a/Package_Handler_Transmitter/package_handler_tx.c
+++ b/Package_Handler_Transmitter/package_handler_tx.c
@@ -1,0 +1,67 @@
+#include "package_handler_tx.h"
+
+byte* struct_to_byte(package pkg){
+	
+	//casts a pointer to byte from pkg address
+	byte *ptrByte  = (byte *) &pkg;
+	
+	return ptrByte;
+	
+}
+
+void set_bmp(package* pkg, float32 bmp){
+
+	pkg->bmp = bmp;
+	
+	return;
+}
+
+void set_gps(package* pkg, float32 gps[3]){
+
+	pkg->gps[0] = gps[0];
+	pkg->gps[1] = gps[1];
+	pkg->gps[2] = gps[2];
+	
+	return;
+}
+
+void set_pkg_no(package* pkg, int32 no){
+
+	pkg->pkg_no = no;
+	
+	return;
+}
+
+float32 get_bmp(package pkg){
+	
+	return pkg.bmp;
+}
+
+float32* get_gps(package pkg){
+	
+	return pkg.gps;
+}
+
+int32 get_pkg_no(package pkg){
+	
+	return pkg.pkg_no;
+}
+
+int main(){
+	
+	package pkg;
+	pkg.bmp = 7.8;
+	pkg.gps[0] = 1.2;
+	pkg.gps[1] = 3.3;
+	pkg.gps[2] = 5.1;
+	pkg.pkg_no = 0;
+	pkg.tk1 = ';';
+	pkg.tk2 = ';';
+	pkg.tk3 = ';';
+	
+	byte *data = struct_to_byte(pkg);
+	
+	printf("%c\n", data[4]);
+	
+	return 0;
+}

--- a/Package_Handler_Transmitter/package_handler_tx.h
+++ b/Package_Handler_Transmitter/package_handler_tx.h
@@ -1,0 +1,73 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define pkg_size_bytes 15
+
+typedef char byte;
+typedef int int32;
+typedef float float32;
+
+typedef struct package{
+	float32 bmp;
+	char tk1;
+	float32 gps[3];
+	char tk2;
+	int32 pkg_no;
+	char tk3;
+}package;
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: converts a package struct to a byte array
+Parameters: a package struct
+Output: pointer to a byte array
+*/
+byte* struct_to_byte(package pkg);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: sets the bpm value of the package
+Parameters: a pointer to a package struct and the bmp value
+Output: nothing
+*/
+void set_bmp(package* pkg, float32 bmp);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: sets the gps value of the package
+Parameters: a pointer to a package struct and the gps array 
+Output: nothing
+*/
+void set_gps(package* pkg, float32 gps[]);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: sets the package number value of the package
+Parameters: a pointer to a package struct and the number value
+Output: nothing
+*/
+void set_pkg_no(package* pkg, int32 no);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: gets the bpm value of the package
+Parameters: a package struct
+Output:the bmp value
+*/
+float32 get_bmp(package pkg);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: gets the pointer to the gps values of the package
+Parameters: a package struct
+Output:the pointer to the gps value values
+*/
+float32* get_gps(package pkg);
+
+/*
+Author: Tiago Bachiega de Almeida
+Function: gets the package number value of the package
+Parameters: a package struct
+Output:the package number
+*/
+int32 get_pkg_np(package pkg);


### PR DESCRIPTION
Esta é a primeira versão da API Package_Handler_Transmitter. Seu objeto é fazer
o tratamento do pacote no transmissor, deixando-o pronto para o envio.